### PR TITLE
Adding main activity as default activity to start

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tk.elevek.proxysetter" >
+    package="tk.elevenk.proxysetter" >
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
             android:name="tk.elevenk.proxysetter.MainActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
     </application>
 


### PR DESCRIPTION
In order to better use external tools to install and execute your app faster e.g. [dryrun](https://github.com/cesarferreira/dryrun)
Adding MainActivity as default activity on manifest 